### PR TITLE
Updates for patch 8.1

### DIFF
--- a/FriendsShare/FriendsShare.lua
+++ b/FriendsShare/FriendsShare.lua
@@ -293,7 +293,7 @@ function FriendsShare_SyncFriendsLists()
 	serverFriends = { }
 	serverNotes = { }
 	-- load friend list from server
-	local numFriends = GetNumFriends()
+	local numFriends = C_FriendList.GetNumFriends()
 	for index = 1, numFriends, 1 do
 		info = C_FriendList.GetFriendInfoByIndex(index)
 		if ( info.name ) then

--- a/FriendsShare/FriendsShare.lua
+++ b/FriendsShare/FriendsShare.lua
@@ -1,177 +1,159 @@
 --[[
 FriendsShare: AddOn to keep a global friends list across alts on the same server.
+
+  name         - friend name (may or may not contain the realm name)
+  index        - index of friend in list (not used locally, but is a passthrough to stock UI)  
+
 ]]
 
 local Version = 30
-local OrigAddFriend
-local OrigRemoveFriend
-local OrigAddIgnore
-local OrigDelIgnore
-local Realm
-local ConnectedRealms = {}
-local PlayerFaction
-local waitTable = {}
-local waitFrame = nil
-local friendsAdded = 0
-local friendsListSynchronized = 0
-local ignoreListSynchronozed = 0
+local CurrentRealm                -- current realm
+local ConnectedRealms = {}        -- list of realms connected to current realm
+local PlayerFaction               -- current player's faction
+local waitTable = {}              -- tasks to run again on delay
+local waitFrame = nil             -- frame to hook for delaying a function
+local flagFriendsAdded = false    -- flag whether we've added friends in sync function 
+local flagFriendsSynced = false   -- flag whether friends have been synced
+local flagIgnoresSynced = false   -- flag whether ignores have been synced
+local updateInterval = 5          -- how many seconds to wait between runs of delayed functions
 
-local function debug (msg)
-	DEFAULT_CHAT_FRAME:AddMessage(msg)
+-- These store the WoW lua API functions we're overloading
+local OrigAddFriend               -- C_FriendList.AddFriend
+local OrigRemoveFriend            -- C_FriendList.RemoveFriend
+local OrigRemoveFriendByIndex     -- C_FriendList.RemoveFriendByIndex
+local OrigAddIgnore               -- C_FriendList.AddIgnore
+local OrigAddOrDelIgnore          -- C_FriendList.AddOrDelIgnore
+local OrigDelIgnore               -- C_FriendList.DelIgnore
+local OrigDelIgnoreByIndex        -- C_FriendList.DelIgnoreByIndex
+local OrigSetFriendNotes          -- C_FriendList.SetFriendNotes
+local OrigSetFriendNotesByIndex   -- C_FriendList.SetFriendNotesByIndex
+
+local function debug(msg)
+	DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare debug: %s", msg))
 end
 
-local function waitOnUpdate (self, elapse)
+local function waitOnUpdate(self, elapsed)
+  self.timeSinceUpdate = self.timeSinceUpdate - elapsed
+  if ( self.timeSinceUpdate > 0 ) then
+    return
+  end
 
 	local count = #waitTable
 	local i = 1
 	while ( i <= count )
 	do
 		local waitRecord = tremove(waitTable,i)
-		local d = tremove(waitRecord,1)
-		local f = tremove(waitRecord,1)
-		local p = tremove(waitRecord,1)
-
-		if ( d > elapse ) then
-			tinsert(waitTable, i, {d-elapse, f, p})
+		local delay = tremove(waitRecord,1)
+		local func = tremove(waitRecord,1)
+		local params = tremove(waitRecord,1)
+		if ( delay > elapsed ) then  -- we need to delay still
+			tinsert(waitTable, i, {delay - elapsed, func, params})
 			i = i + 1
 		else
 			count = count - 1
-			f(unpack(p))
+			func(unpack(params))      -- execute the delayed function
 		end
 	end
-
 	if ( #waitTable == 0 ) then
 		waitFrame:SetScript("onUpdate", nil)
 	end
 end
 
 local function wait(delay, func, ...)
-
 	if ( type(delay) ~= "number" or type(func) ~= "function" ) then
 		return false
 	end
-
 	if ( waitFrame == nil ) then
 		waitFrame = CreateFrame("Frame", "WaitFrame", UIParent)
 	end
-
+  waitFrame.timeSinceUpdate = updateInterval
 	waitFrame:SetScript("onUpdate", waitOnUpdate)
-
 	tinsert(waitTable, {delay, func, {...}})
-
 	return true
 end
 
-function FriendsShare_PrintableName2(name)
-
+function FriendsShare_TitleCase(name)
+  -- capitalize first character of names & realms
 	if ( name == nil ) then
 		return
 	end
-
-	if ( string.len(name) < 2 ) then
-		return string.upper(name)
+	name = name:gsub("^%l", string.upper)
+	local dash = string.find(name, "-")
+	if ( dash == nil ) then
+		return name
 	end
-
-	return string.upper(string.sub(name, 1, 1)) .. string.sub(name, 2)
+	local character = string.sub(name, 1, dash - 1)
+	local realm = string.sub(name, dash + 1) 
+	return character .. "-" ..  realm:gsub("^%l", string.upper)
 end
 
-function FriendsShare_PrintableName(name)
-
+function FriendsShare_GetFQCharName(name)
+  -- returns fully qualified character name (adds current realm to local characters)
 	if ( name == nil ) then
 		return
 	end
-
-	local p = string.find(name, "-")
-	if ( p == nil ) then
-		return FriendsShare_PrintableName2(name)
-	end
-
-	local c = string.sub(name, 1, p-1)
-	local r = string.sub(name, p+1)
-
-	return FriendsShare_PrintableName2(c) .. "-" .. FriendsShare_PrintableName2(r)
-end
-
-function FriendsShare_FullQualifiedCharacterName(name)
-
-	if ( name == nil ) then
-		return
-	end
-
 	if ( string.match(name, "-") == nil ) then
-		name = name .. "-" .. Realm
+		name = name .. "-" .. CurrentRealm
 	end
-
 	return name
 end
 
-function FriendsShare_ShortNameForLocalCharacters(name)
-
+function FriendsShare_StripLocalRealm(name)
+	-- Removes the -RealmName for local characters. This is mandatory for WoW API calls.
 	if ( name == nil ) then
 		return
 	end
-
 	local p = string.find(name, "-")
 	if ( p ~= nil ) then
 		local r = string.sub(name, p+1)
-		if ( string.lower(r) == string.lower(Realm) ) then
+		if ( string.lower(r) == string.lower(CurrentRealm) ) then
 			return string.sub(name, 1, p-1)
 		end
 	end
-
 	return name
 end
 
-function FriendsShare_IsFriendFromMyCollectedRealmPool(name)
-
+function FriendsShare_IsOnConnectedRealm(name)
 	if ( name == nil ) then
 		return
 	end
-
 	local p = string.find(name, "-")
 	if ( p == nil ) then
 		return
 	end
-
 	local r = string.sub(name, p+1)
-
 	local i = 1
 	while ( ConnectedRealms[i] ~= nil ) do
-		if (string.lower(ConnectedRealms[i]) == r) then
+		if ( string.lower(ConnectedRealms[i]) == r ) then
 			return true
 		end
 		i = i + 1
 	end
-
 	return false
 end
 
 function FriendsShare_CommandHandler(msg)
-
 	if ( msg == "rebuild" ) then
-
-		local index, value
-
-		for index,value in pairs(FriendsShareFriends2) do
-			if (FriendsShare_IsFriendFromMyCollectedRealmPool(index)) then
-				FriendsShareFriends2[index] = nil
+		local name
+		for name, _ in pairs(FriendsShareFriends2) do
+			if ( FriendsShare_IsOnConnectedRealm(name) ) then
+				FriendsShareFriends2[name] = nil
 			end
 		end
-
-		for index,value in pairs(FriendsShareIgnored2) do
-			if ( FriendsShareIgnored2[index] == "ignore" ) then
-				FriendsShareIgnored2[index] = nil
+		for name, _ in pairs(FriendsShareIgnored2) do
+			if ( FriendsShareIgnored2[name] == "ignore" ) then
+			  if ( FriendsShare_IsOnConnectedRealm(name) ) then
+	  			FriendsShareIgnored2[name] = nil
+        end
 			end
 		end
-
-		for index,value in pairs(FriendsShareNotes2) do
-			if (FriendsShare_IsFriendFromMyCollectedRealmPool(index)) then
-				FriendsShareNotes2[index] = nil
+		for name, _ in pairs(FriendsShareNotes2) do
+			if ( FriendsShare_IsOnConnectedRealm(name) ) then
+				FriendsShareNotes2[name] = nil
 			end
 		end
-		
-		friendsListSynchronized = 0
-		ignoreListSynchronozed = 0
+		flagFriendsSynced = false
+		flagIgnoresSynced = false
 		FriendsShare_SyncLists()
 		DEFAULT_CHAT_FRAME:AddMessage("FriendsShare Resurrection: Realmwide friendslist rebuilt.")
 	else
@@ -179,379 +161,347 @@ function FriendsShare_CommandHandler(msg)
 	end
 end
 
-function FriendsShare_RemoveFriend(friend)
 
-	-- "friend" can either be a string with the name
-	-- of a friend or a number which is the friend index
-	if ( tonumber( friend ) == nil ) then
-		-- cannot convert to number, therefore it has to be a
-		-- string containing the name
-		local friendName = FriendsShare_FullQualifiedCharacterName(friend)
-		FriendsShareFriends2[ string.lower(friendName) ] = "delete"
-		FriendsShareNotes2[ string.lower(friendName) ] = nil
+------------------------------------------------------------------------------
+-- Overloaded functions start here
 
-		-- The WoW API requires a name without a dash for local characters
-		friend = FriendsShare_ShortNameForLocalCharacters(friend)
-	else
-		-- "friend" could be converted to a number and therefore
-		-- cannot be a string containing the name
-		local friendName = GetFriendInfo(friend)
-		if ( friendName ) then
-			friendName = FriendsShare_FullQualifiedCharacterName(friendName)
-			FriendsShareFriends2[ string.lower( friendName) ] = "delete"
-			FriendsShareNotes2[ string.lower( friendName ) ] = nil
-		end
-	end
-
-	OrigRemoveFriend(friend)
+function FriendsShare_RemoveFriend(name)
+	name = FriendsShare_StripLocalRealm(name)
+	local removed = OrigRemoveFriend(name)   -- C_FriendList.RemoveFriend returns result, so we need capture 
+	if ( removed ) then
+    -- only record the deletion if it was successful
+    name = FriendsShare_GetFQCharName(name)
+	  FriendsShareFriends2[string.lower(name)] = "delete"
+  	FriendsShareNotes2[string.lower(name)] = nil
+  end
+  return removed     
 end
 
-function FriendsShare_AddFriend(friend)
-
-	-- The WoW API requires a name without a dash for local characters
-	friend = FriendsShare_ShortNameForLocalCharacters(friend)
-
-	OrigAddFriend(friend)
-
-	if ( friend == "target" ) then
-		friend = UnitName("target")
+function FriendsShare_RemoveFriendByIndex(index)
+  -- Use C_FriendList.GetFriendInfoByIndex instead
+	local name = C_FriendList.GetFriendInfo(index)
+	if ( name ) then
+		name = FriendsShare_GetFQCharName(name)
+		FriendsShareFriends2[string.lower(name)] = "delete"
+		FriendsShareNotes2[string.lower(name)] = nil
 	end
-
-	friend = FriendsShare_FullQualifiedCharacterName(friend)
-
-	FriendsShareFriends2[string.lower(friend)] = PlayerFaction
+	OrigRemoveFriendByIndex(index)
 end
 
-function FriendsShare_DelIgnore(friend)
-
-	-- "friend" can either be a string with the name
-	-- of a friend or a number which is the friend index
-	if ( tonumber( friend ) == nil ) then
-		-- cannot convert to number, therefore it has to be a
-		-- string containing the name
-		local friendName = FriendsShare_FullQualifiedCharacterName(friend)
-		FriendsShareIgnored2[ string.lower(friendName) ] = "delete"
-
-		-- The WoW API requires a name without a dash for local characters
-		friend = FriendsShare_ShortNameForLocalCharacters(friend)
-	else
-		-- "friend" could be converted to a number and therefore
-		-- cannot be a string containing the name
-		local friendName = GetIgnoreName(friend)
-		if ( friendName ) then
-			friendName = FriendsShare_FullQualifiedCharacterName(friendName)
-			FriendsShareIgnored2[ string.lower( friendName) ] = "delete"
-		end
+function FriendsShare_AddFriend(name)
+	name = FriendsShare_StripLocalRealm(name)
+	OrigAddFriend(name)
+	if ( name == "target" ) then
+		name = UnitName("target")
 	end
-
-	OrigDelIgnore(friend)
+	name = FriendsShare_GetFQCharName(name)
+	FriendsShareFriends2[string.lower(name)] = PlayerFaction
 end
 
-function FriendsShare_AddIgnore(friend)
-
-	-- The WoW API requires a name without a dash for local characters
-	friend = FriendsShare_ShortNameForLocalCharacters(friend)
-
-	OrigAddIgnore(friend)
-
-	if ( friend == "target" ) then
-		friend = UnitName("target")
-	end
-
-	friend = FriendsShare_FullQualifiedCharacterName(friend)
-
-	FriendsShareIgnored2[string.lower(friend)] = "ignore"
+function FriendsShare_DelIgnore(name)
+	name = FriendsShare_StripLocalRealm(name)
+	local removed = OrigDelIgnore(name)
+	if ( removed ) then
+    -- only record the deletion if it was successful
+    name = FriendsShare_GetFQCharName(name)
+	  FriendsShareIgnored2[string.lower(name)] = "delete"
+  end
+  return removed
 end
 
-function FriendsShare_SetFriendNotes(friendIndex, noteText)
-
-	local friendName
-	if ( tonumber( friendIndex ) == nil ) then
-		-- cannot convert to number, therefore it has to be a
-		-- string containing the name
-		friendName = FriendsShare_FullQualifiedCharacterName(friendIndex)
-
-		-- The WoW API requires a name without a dash for local characters
-		friendIndex = FriendsShare_ShortNameForLocalCharacters(friendIndex)
-	else
-		-- "friend" could be converted to a number and therefore
-		-- cannot be a string containing the name
-		friendName = FriendsShare_FullQualifiedCharacterName(string.lower(GetFriendInfo(friendIndex)))
+function FriendsShare_DelIgnoreByIndex(index)
+	name = C_FriendList.GetIgnoreName(index)
+	if ( name ) then
+		name = FriendsShare_GetFQCharName(name)
+		FriendsShareIgnored2[string.lower(name)] = "delete"
 	end
+	OrigDelIgnoreByIndex(index)
+end
 
-	FriendsShare_origSetFriendNotes(friendIndex, noteText)
+function FriendsShare_AddIgnore(name)
+	name = FriendsShare_StripLocalRealm(name)
+	OrigAddIgnore(name)
+	if ( name == "target" ) then
+		name = UnitName("target")
+	end
+	name = FriendsShare_GetFQCharName(name)
+	FriendsShareIgnored2[string.lower(name)] = "ignore"
+end
 
-	if ( friendName ) then
-		FriendsShareNotes2[string.lower(friendName)] = noteText
+function FriendsShare_AddOrDelIgnore(name)
+  -- this toggles the ignore status (used on the context menu in the friends list)
+ 	name = FriendsShare_GetFQCharName(name)
+  if ( C_FriendList.IsIgnored(name) ) then
+	  if ( FriendsShareIgnored2[string.lower(name)] == "ignore" ) then
+	    FriendsShareIgnored2[string.lower(name)] = "delete"
+    end
+  else
+	  FriendsShareIgnored2[string.lower(name)] = "ignore"
+  end  
+	name = FriendsShare_StripLocalRealm(name)
+  OrigAddOrDelIgnore(name)
+end
+
+function FriendsShare_SetFriendNotes(name, noteText)
+	name = FriendsShare_GetFQCharName(name)
+	FriendsShareNotes2[string.lower(name)] = noteText
+	name = FriendsShare_StripLocalRealm(name)
+	local found = OrigSetFriendNotes(name, noteText)
+  return found
+end
+
+function FriendsShare_SetFriendNotesByIndex(index, noteText)
+	local name = FriendsShare_GetFQCharName(string.lower(C_FriendList.GetFriendInfoByIndex(index)))
+	if ( name ) then
+    name = FriendsShare_GetFQCharName(name)
+		FriendsShareNotes2[string.lower(name)] = noteText
 	else
 		DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: ERROR: Could not save new note to database. This note will be overwritten the next time you log in."))
 	end
+	OrigSetFriendNotesByIndex(index, noteText)
 end
 
+--
+------------------------------------------------------------------------------
+
 function FriendsShare_SyncFriendsLists()
-
-	local iItem, currentFriend, note, trash, localFriends, localNotes
+	local index, name, notes, serverFriends, serverNotes
 	local retval = 0 -- 0 = ok; -1 = not ready; -2 = delay for notes
-
-	localFriends = { }
-	localNotes = { }
-
+	serverFriends = { }
+	serverNotes = { }
 	-- load friend list from server
 	local numFriends = GetNumFriends()
-	for iItem = 1, numFriends, 1 do
-		currentFriend, trash, trash, trash, trash, trash, note = GetFriendInfo(iItem)
-
-		if ( currentFriend ) then
-			currentFriend = FriendsShare_FullQualifiedCharacterName(currentFriend)
-
-			localFriends[string.lower(currentFriend)] = 1
-			localNotes[string.lower(currentFriend)] = note
-
+	for index = 1, numFriends, 1 do
+		info = C_FriendList.GetFriendInfoByIndex(index)
+		if ( info.name ) then
+			name = FriendsShare_GetFQCharName(info.name)
+			serverFriends[string.lower(name)] = 1
+			serverNotes[string.lower(name)] = info.notes
 			-- debug(string.format("friend: %s", string.lower(currentFriend)))
 		else
-			-- friend list not loaded from server. we will try again later.
+			-- friend list not loaded from server; we will try again later.
 			return -1
 		end
 	end
 
-	local index, value
-	for index,value in pairs(localFriends) do
-		if ( FriendsShareFriends2[index] == "delete" ) then
-			DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: Removing %s from friends list.", FriendsShare_PrintableName(index)))
-			RemoveFriend(index)
+	for name, _ in pairs(serverFriends) do
+		if ( FriendsShareFriends2[name] == "delete" ) then
+			DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: Removing %s from friends list.", FriendsShare_TitleCase(name)))
+			C_FriendList.RemoveFriend(name)
 		else
-			FriendsShareFriends2[index] = PlayerFaction
-
-			if ( FriendsShareNotes2[index] ~= nil ) then
-				if ( FriendsShareNotes2[index] == "" ) then
-					if ( localNotes[index] ~= nil ) then
-						DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: Removeing note for %s.", FriendsShare_PrintableName(index)))
-						FriendsShare_origSetFriendNotes(FriendsShare_ShortNameForLocalCharacters(index), "")
+			FriendsShareFriends2[name] = PlayerFaction
+			if ( FriendsShareNotes2[name] ~= nil ) then     -- we have a note in the FSR database
+				if ( FriendsShareNotes2[name] == "" ) then    -- note in FSR database is empty
+					if ( serverNotes[name] ~= nil ) then        -- but, note on server has a value, so we'll remove it 
+						DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: Removing note for %s.", FriendsShare_TitleCase(name)))
+						OrigSetFriendNotes(FriendsShare_StripLocalRealm(name), "")
 					end
 				else
-					if (localNotes[index] == nil or FriendsShareNotes2[index] ~= localNotes[index]) then
-						DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: Setting note \"%s\" for %s.", FriendsShareNotes2[index], FriendsShare_PrintableName(index)))
-						FriendsShare_origSetFriendNotes(FriendsShare_ShortNameForLocalCharacters(index), FriendsShareNotes2[index])
+					if ( serverNotes[name] == nil or FriendsShareNotes2[name] ~= serverNotes[name] ) then  -- update server note with one stored in FSR database
+						DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: Setting note \"%s\" for %s.", FriendsShareNotes2[name], FriendsShare_TitleCase(name)))
+						OrigSetFriendNotes(FriendsShare_StripLocalRealm(name), FriendsShareNotes2[name])
 					end
 				end
-			elseif (localNotes[index] ~= nil) then
-				-- save to database
-				FriendsShareNotes2[index] = localNotes[index]
+			elseif ( serverNotes[name] ~= nil ) then          
+				FriendsShareNotes2[name] = serverNotes[name]  -- store the server note to the database
 			end
 		end
 	end
 
-	if ( friendsAdded == 0 ) then
-		for index,value in pairs(FriendsShareFriends2) do
-			if (FriendsShare_IsFriendFromMyCollectedRealmPool(index)) then
-				if ( value == PlayerFaction and localFriends[index] == nil and not (index == string.lower(UnitName("player") .. "-" .. Realm))) then
-					DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: Adding %s to friends list.", FriendsShare_PrintableName(index)))
-					AddFriend(index)
-
-					if (FriendsShareNotes2[index] ~= nil) then
+	if ( flagFriendsAdded == false ) then
+    local faction
+		for name, faction in pairs(FriendsShareFriends2) do
+			if ( FriendsShare_IsOnConnectedRealm(name) ) then
+				if ( faction == PlayerFaction and serverFriends[name] == nil and not (name == string.lower(UnitName("player") .. "-" .. CurrentRealm))) then
+					DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: Adding %s to friends list.", FriendsShare_TitleCase(name)))
+					OrigAddFriend(name)
+					if ( FriendsShareNotes2[name] ~= nil ) then
 						-- We cannot set the notes now because adding a new user takes
 						-- some time. We return false which triggers another update.
-
 						retval = -2
 					end
 				end
 			end
 		end
-
 		-- only add friends once to prevent the eternal AddFriend() spam from removed friends.
-		friendsAdded = 1
+		flagFriendsAdded = true
 	end
-
 	return retval
 end
 
 function FriendsShare_SyncIgnoreList()
-
-	local iItem, currentFriend, localIgnores
+	local index, name, serverIgnores
 	local retval = 0 -- 0 = ok; -1 = not ready
-
-	localIgnores = { }
-
+	serverIgnores = { }
 	-- load ignore list from server
 	local numIgnores = C_FriendList.GetNumIgnores()
-	for iItem = 1, numIgnores, 1 do
-		currentFriend = GetIgnoreName(iItem)
-
-		if ( currentFriend and currentFriend ~= UNKNOWN ) then
-			currentFriend = FriendsShare_FullQualifiedCharacterName(currentFriend)
-			localIgnores[string.lower(currentFriend)] = 1
+	for index = 1, numIgnores, 1 do
+		name = C_FriendList.GetIgnoreName(index)
+		if ( name and name ~= UNKNOWN ) then
+			name = FriendsShare_GetFQCharName(name)
+			serverIgnores[string.lower(name)] = 1
 		else
 			-- ignore list not loaded from server. we will try again later.
 			return -1
 		end
 	end
 
-	local index, value
-
-	for index,value in pairs(localIgnores) do
-		if ( FriendsShareIgnored2[index] and FriendsShareIgnored2[index] == "delete" ) then
-			DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: Removing %s from ignore list.", FriendsShare_PrintableName(index)))
-			DelIgnore(index)
+	for name, _ in pairs(serverIgnores) do
+		if ( FriendsShareIgnored2[name] and FriendsShareIgnored2[name] == "delete" ) then
+			DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: Removing %s from ignore list.", FriendsShare_TitleCase(name)))
+      OrigDelIgnore(name)
 		else
-			FriendsShareIgnored2[index] = "ignore"
+			FriendsShareIgnored2[name] = "ignore"
 		end
 	end
 
-	for index,value in pairs(FriendsShareIgnored2) do
-		if ( value == "ignore" and localIgnores[index] == nil and not (index == string.lower(UnitName("player") .. "-" .. Realm))) then
-			DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: Adding %s to ignore list.", FriendsShare_PrintableName(index)))
-			AddIgnore(index)
-		end
+	for name, value in pairs(FriendsShareIgnored2) do
+		if ( FriendsShare_IsOnConnectedRealm(name) ) then
+	  	if ( value == "ignore" and serverIgnores[name] == nil and not (name == string.lower(UnitName("player") .. "-" .. CurrentRealm))) then
+		  	DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: Adding %s to ignore list.", FriendsShare_TitleCase(name)))
+		  	OrigAddIgnore(name)
+		  end
+    end
 	end
 
 	return retval
 end
 
 function FriendsShare_RemoveUnknownEntriesFromIgnoreList()
-
-	local currentIgnore, currentName
-
-	for currentIgnore = C_FriendList.GetNumIgnores(), 1, -1
-	do
-		currentName = GetIgnoreName(currentIgnore)
-
-		if ( currentName and currentName == UNKNOWN ) then
-			DelIgnore(currentIgnore)
+	local name, index
+	for index = C_FriendList.GetNumIgnores(), 1, -1 do
+		name = GetIgnoreName(index)
+		if ( name and name == UNKNOWN ) then
+			OrigDelIgnoreByIndex(index)
 		end
 	end
 end
 
 function FriendsShare_SyncLists()
-
 	local retval = true
-
 	-- initialize FriendsShareFriends2
 	if ( FriendsShareFriends2 == nil ) then
 		FriendsShareFriends2 = { }
 	end
-
 	-- initialize FriendsShareNotes2
 	if ( FriendsShareNotes2 == nil ) then
 		FriendsShareNotes2 = { }
 	end
-
 	-- initialize FriendsShareIgnored2
 	if ( FriendsShareIgnored2 == nil ) then
 		FriendsShareIgnored2 = { }
 	end
-
 	local reportFLSuccess = 0
 	local reportILSuccess = 0
-
-	if ( friendsListSynchronized == 0 ) then
+	if ( flagFriendsSynced == false ) then
 		local sfl = FriendsShare_SyncFriendsLists()
-
 		if ( sfl == -1 ) then
 			-- not ready
 			return false
 		end
-
 		if ( sfl == -2 ) then
 			retval = false
 		end
-
 		if ( sfl == 0 ) then
-			friendsListSynchronized = 1
+			flagFriendsSynced = true
 			reportFLSuccess = 1
 		end
 	end
-
-	if ( ignoreListSynchronozed == 0 ) then
+	if ( flagIgnoresSynced == false ) then
 		local sil = FriendsShare_SyncIgnoreList()
-
 		if ( sil == -1 ) then
 			-- not ready
 			retval = false
 		end
-
 		if ( sil == 0 ) then
-			ignoreListSynchronozed = 1
+			flagIgnoresSynced = true
 			reportILSuccess = 1
 		end
 	end
-
-	if (( reportFLSuccess == 1 ) and ( reportILSuccess == 1 )) then
+	if ( ( reportFLSuccess == 1 ) and ( reportILSuccess == 1 ) ) then
 		DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: friends and ignore list synchronized."))
 	elseif ( reportFLSuccess == 1 ) then 
 		DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: friends list synchronized."))
 	elseif ( reportILSuccess == 1 ) then
 		DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: ignore list synchronized."))
 	end
-
 	return retval
 end
 
 local function PlanSync(delay)
-
 	if ( FriendsShare_SyncLists() ) then
 		-- successfully synced
 		return
 	end
-
 	if ( delay >= 240 ) then
-		if ( friendsListSynchronized ~= 1 ) then
+		if ( flagFriendsSynced == false ) then
 			DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: friends list not ready, giving up."))
-
 			return
 		end
-
 		-- remove unknown entries from ignore list
 		FriendsShare_RemoveUnknownEntriesFromIgnoreList()
 		delay = 30
-
 		return
 	end
-
-	-- delay = math.min(2 * delay, 60)
 	delay = 2 * delay
-
 	local notReadyList = "friends"
-	if ( friendsListSynchronized == 1 ) then
+	if ( flagFriendsSynced == true ) then
 		notReadyList = "ignore"
 	end
 	DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection: %s list not ready, will try again in %i seconds.", notReadyList, delay))
-
-	ShowFriends()
-
+	C_FriendList.ShowFriends()
 	wait(delay, PlanSync, delay)
 end
 
 local function EventHandler(self, event, ...)
-
 	if ( event == "PLAYER_ENTERING_WORLD" ) then
 		self:UnregisterEvent("PLAYER_ENTERING_WORLD")
 
 		-- Realms like "Die Arguswacht" must be called "DieArguswacht" in the friends list.
-		Realm = string.gsub(GetRealmName(), "%s", "")
+		CurrentRealm = string.gsub(GetRealmName(), "%s", "")
 		PlayerFaction = UnitFactionGroup("player")
 
 		SLASH_FRIENDSSHARE1 = "/friendsshare"
 		SlashCmdList["FRIENDSSHARE"] = function(msg) FriendsShare_CommandHandler(msg) end
 
-		OrigAddFriend = AddFriend
-		AddFriend = FriendsShare_AddFriend
+    -- 
+    -- These are functions that were deprecated in 8.1.0, and will be removed in the next expansion.
+    --
+    -- Use C_FriendList.AddFriend instead
+    OrigAddFriend = C_FriendList.AddFriend
+		C_FriendList.AddFriend = FriendsShare_AddFriend
 
-		OrigRemoveFriend = RemoveFriend
-		RemoveFriend = FriendsShare_RemoveFriend
+		-- Use C_FriendList.RemoveFriend or C_FriendList.RemoveFriendByIndex instead
+		OrigRemoveFriend = C_FriendList.RemoveFriend
+		C_FriendList.RemoveFriend = FriendsShare_RemoveFriend
+		OrigRemoveFriendByIndex = C_FriendList.RemoveFriendByIndex
+    C_FriendList.RemoveFriendByIndex = FriendsShare_RemoveFriendByIndex
 
-		OrigAddIgnore = AddIgnore
-		AddIgnore = FriendsShare_AddIgnore
+    -- Use C_FriendList.AddIgnore instead
+		OrigAddIgnore = C_FriendList.AddIgnore
+		C_FriendList.AddIgnore = FriendsShare_AddIgnore
 
-		OrigDelIgnore = DelIgnore
-		DelIgnore = FriendsShare_DelIgnore
+    -- Use C_FriendList.AddOrDelIgnore instead
+    -- Fulz: this overload is needed to capture the context menu toggle in the friends list
+    OrigAddOrDelIgnore = C_FriendList.AddOrDelIgnore
+    C_FriendList.AddOrDelIgnore = FriendsShare_AddOrDelIgnore
 
-		FriendsShare_origSetFriendNotes = SetFriendNotes
-		SetFriendNotes = FriendsShare_SetFriendNotes
+    -- Use C_FriendList.DelIgnore or C_FriendList.DelIgnoreByIndex instead
+		OrigDelIgnore = C_FriendList.DelIgnore
+		C_FriendList.DelIgnore = FriendsShare_DelIgnore
+		OrigDelIgnoreByIndex = C_FriendList.DelIgnoreByIndex
+		C_FriendList.DelIgnoreByIndex = FriendsShare_DelIgnoreByIndex
 
-		ConnectedRealms = GetAutoCompleteRealms()
-		if ( ConnectedRealms == nil ) then
+    -- Use C_FriendList.SetFriendNotes or C_FriendList.SetFriendNotesByIndex instead
+		OrigSetFriendNotes = C_FriendList.SetFriendNotes
+		C_FriendList.SetFriendNotes = FriendsShare_SetFriendNotes
+		OrigSetFriendNotesByIndex = C_FriendList.SetFriendNotesByIndex
+		C_FriendList.SetFriendNotesByIndex = FriendsShare_SetFriendNotesByIndex
+
+		ConnectedRealms = GetAutoCompleteRealms()  -- Fulz: this will always return a table, even if it's empty, so we
+		if ( ConnectedRealms[1] == nil ) then      --       check first value in returned table instead
 			-- debug("FriendsShare Resurrection: Your realm is not conected.")
-			ConnectedRealms = { Realm }
+			ConnectedRealms = { CurrentRealm }
 		else
 			local i = 1
 			while ( ConnectedRealms[i] ~= nil ) do
@@ -564,7 +514,7 @@ local function EventHandler(self, event, ...)
 
 		DEFAULT_CHAT_FRAME:AddMessage(string.format("FriendsShare Resurrection %i loaded.", Version ))
 
-		-- debug(string.format("FriendsShare Resurrection: Your realm is %s.", Realm ))
+		-- debug(string.format("FriendsShare Resurrection: Your realm is %s.", CurrentRealm ))
 		-- debug(string.format("FriendsShare Resurrection: Your faction is %s.", PlayerFaction ))
 	end
 end

--- a/FriendsShare/FriendsShare.toc
+++ b/FriendsShare/FriendsShare.toc
@@ -1,6 +1,6 @@
 ## Interface: 80100
 ## Title: FriendsShare Resurrection
-## Author: Oystein (Resurrected by Kring)
+## Author: Oystein (Resurrected by Kring), updates by Fulzamoth & Tubiakou
 ## Notes: AddOn to keep a global friends list across alts on the same server
 ## OptionalDeps:
 ## Dependencies:

--- a/FriendsShare/readme.txt
+++ b/FriendsShare/readme.txt
@@ -34,7 +34,7 @@ Unreleased
  * Major updates for patch 8.1, which introduced changes to Friends
    lua API
  * Addon now works on non-connected realms again
- * Ignores properly sync only connected realms
+ * Ignores are now properly sync'ed only across connected realms
  * Add/remove of friend from ignore list is tracked properly
  
 Version 30

--- a/FriendsShare/readme.txt
+++ b/FriendsShare/readme.txt
@@ -30,6 +30,13 @@ him.
 
 *** Changelog
 
+Unreleased
+ * Major updates for patch 8.1, which introduced changes to Friends
+   lua API
+ * Addon now works on non-connected realms again
+ * Ignores properly sync only connected realms
+ * Add/remove of friend from ignore list is tracked properly
+ 
 Version 30
  * Fixed LUA error (Thanks, raysmith59;
    https://github.com/skirmess/friends-share-resurrection/issues/1)

--- a/changelog.md
+++ b/changelog.md
@@ -17,14 +17,19 @@ This release is a major refactoring and updating of the addon by Fulzamoth & Tub
     * **SetFriendNotes** - use **C_FriendList.SetFriendNotes** or **C_FriendList.SetFriendNotesByIndex** instead
     * **GetFriendInfo** - use **C_FriendList.GetFriendInfo** or **C_FriendList.GetFriendInfoByIndex** instead
 
+* **C_FriendList.AddFriend** takes notes as an optional argument, so we simplified the sync to use that instead of delaying and running a note-sync pass separately.
 * Fixed a problem that prevented the addon from working on non-connected realms.
 * The ignore list was incorrectly syncing all ignores rather than just those for the connected realms. We've updated it to match the logic used for the friends list.
 * Variable names were standardized to better match the API use. *name* is the character name, and may or may not have include the realm. *index* is used only with the ...ByIndex API functions.
 * Some function names have been renamed to make it clearer what they're doing.
+* Switched to triggering on the PLAYER_LOGIN event instead of PLAYER_ENTERING_WORLD, since we don't care to run when a player respawns at a graveyard or enters/leaves and instance.
+* Shortened initial sync delay to 10 seconds.
+
 
 ## Added
 
 * Toggling the ignore status of a friend on your friends list was not captured by the addon. We've added an overload of **C_FriendList.AddOrDelIgnore** to trap it.
 * Some API functions return a value that the UI expects. These are passed through now.
 * Added an update interval setting to avoid looping through the wait table on each screen update.
+* Documented the arguments and returns for the API overloads.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,30 @@
+# Unreleased - 2019-01-07 
+
+This release is a major refactoring and updating of the addon by Fulzamoth & Tubiakou.
+
+## Changed
+
+* Most of the old lua API functions for working with friends were deprecated in 8.1.0, and will be removed in the next expansion. 
+    * **AddFriend** - use **C_FriendList.AddFriend** instead
+    * **AddIgnore** - use **C_FriendList.AddIgnore** instead
+    * **AddOrDelIgnore** - use **C_FriendList.AddOrDelIgnore** instead
+    * **GetIgnoreName** - use **C_FriendList.GetIgnoreName** instead
+
+    The following four functions previously took a name or index to identify the friend being modified. As of 8.1.0 they have each been split into separate functions with a _...ByIndex_ function for use with indexes.
+    
+    * **DelIgnore** - use **C_FriendList.DelIgnore** or **C_FriendList.DelIgnoreByIndex** instead
+    * **RemoveFriend** - has been split into two functions: **C_FriendList.RemoveFriend** or **C_FriendList.RemoveFriendByIndex.** The correct function must be called to remove a friend by name or index. 
+    * **SetFriendNotes** - use **C_FriendList.SetFriendNotes** or **C_FriendList.SetFriendNotesByIndex** instead
+    * **GetFriendInfo** - use **C_FriendList.GetFriendInfo** or **C_FriendList.GetFriendInfoByIndex** instead
+
+* Fixed a problem that prevented the addon from working on non-connected realms.
+* The ignore list was incorrectly syncing all ignores rather than just those for the connected realms. We've updated it to match the logic used for the friends list.
+* Variable names were standardized to better match the API use. *name* is the character name, and may or may not have include the realm. *index* is used only with the ...ByIndex API functions.
+* Some function names have been renamed to make it clearer what they're doing.
+
+## Added
+
+* Toggling the ignore status of a friend on your friends list was not captured by the addon. We've added an overload of **C_FriendList.AddOrDelIgnore** to trap it.
+* Some API functions return a value that the UI expects. These are passed through now.
+* Added an update interval setting to avoid looping through the wait table on each screen update.
+

--- a/tests.md
+++ b/tests.md
@@ -1,0 +1,36 @@
+# Testing
+
+The following should be checked when the addon is updated. After each individual test logout and check that *WTF/Account/.../SavedVariables/FriendsShare.lua* properly reflects the expected state. After logging in, wait 30 seconds to see that the updates are applied. For tests with notes and additional 60 seconds wait will be necessary for them to be synced.
+
+The tests should be repeated for both of the following scenarios:
+
+* While logged onto a realm that is not connected, test with a local realm friend.
+* While logged onto a connected realm, test with a friend on another realm.
+    
+## Adding Friends
+1. Add friend via Friends List pane
+2. Add via `/friend` slash command
+
+## Removing Friends
+1. Remove friend via Friends List pane
+2. Remove friend via `/removefriend` slash command
+
+## Ignoring
+1. Add ignore via Ignote list pane
+2. Add ignore via `/ignore` slash command
+
+## Removing Ignore
+1. Remove ignore by selecting character in ignore list and clicking *Remove Player*
+2. Remove by using `/unignore` slash command
+
+## Ignoring a Friend
+The right-click context menu on a friend in the Friends UI calls a toggle API function that needs to be tested separately:
+1. Toggle on an ignore via right-clicking on a friend in the friends list UI
+2. Toggle off an ignore via right-click on an ignored friend in friends list UI
+
+## Adding a Note
+1. Add a note to a friend by right-clicking, selecting *Set Note*, and adding note text.
+2. Edit the note via the same menu, and clear the note text.
+
+## Rebuild
+1. Run `/friendsshare rebuild`.


### PR DESCRIPTION
This release is a major refactoring and updating of the addon by Fulzamoth & Tubiakou.

## Changed

* Most of the old lua API functions for working with friends were deprecated in 8.1.0, and will be removed in the next expansion. 
    * **AddFriend** - use **C_FriendList.AddFriend** instead
    * **AddIgnore** - use **C_FriendList.AddIgnore** instead
    * **AddOrDelIgnore** - use **C_FriendList.AddOrDelIgnore** instead
    * **GetIgnoreName** - use **C_FriendList.GetIgnoreName** instead

    The following four functions previously took a name or index to identify the friend being modified. As of 8.1.0 they have each been split into separate functions with a _...ByIndex_ function for use with indexes.
    
    * **DelIgnore** - use **C_FriendList.DelIgnore** or **C_FriendList.DelIgnoreByIndex** instead
    * **RemoveFriend** - has been split into two functions: **C_FriendList.RemoveFriend** or **C_FriendList.RemoveFriendByIndex.** The correct function must be called to remove a friend by name or index. 
    * **SetFriendNotes** - use **C_FriendList.SetFriendNotes** or **C_FriendList.SetFriendNotesByIndex** instead
    * **GetFriendInfo** - use **C_FriendList.GetFriendInfo** or **C_FriendList.GetFriendInfoByIndex** instead

* **C_FriendList.AddFriend** takes notes as an optional argument, so we simplified the sync to add friends and notes in one pass.
* Fixed a problem that prevented the addon from working on non-connected realms.
* The ignore list was incorrectly syncing all ignores rather than just those for the connected realms. We've updated it to match the logic used for the friends list.
* Variable names were standardized to better match the API use. *name* is the character name, and may or may not have include the realm. *index* is used only with the ...ByIndex API functions.
* Some function names have been renamed to make it clearer what they're doing.
* Switched to triggering on the PLAYER_LOGIN event instead of PLAYER_ENTERING_WORLD, since we don't care to run when a player respawns at a graveyard or enters/leaves and instance.
* Shortened initial sync delay to 10 seconds.


## Added

* Toggling the ignore status of a friend on your friends list was not captured by the addon. We've added an overload of **C_FriendList.AddOrDelIgnore** to trap it.
* Some API functions return a value that the UI expects. These are passed through now.
* Added an update interval setting to avoid looping through the wait table on each screen update.
* Documented the arguments and returns for the API overloads.
